### PR TITLE
Bump base python image to 3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.13-slim
 
 EXPOSE 80/tcp
 


### PR DESCRIPTION
besides updating the interpreter version, this also reduces the image size by almost 10 times from:
```
windowpositionassistantproxy-web (...) 1.01GB
```
to:
```
windowpositionassistantproxy-web (...) 135MB
```

this is based on #1 and should be merged after that one